### PR TITLE
Headless System and `tmux` configurations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,11 @@
       # Different configuration are selected by adding #config after the nixos
       # directory. For example `nixos-rebuild switch --flake /etc/nixos#default`
       # The default configuration configures a headless system.
-      default = nixpkgs.lib.nixosSystem {
+      headless = nixpkgs.lib.nixosSystem {
         specialArgs = {inherit inputs;};
         modules = [
           ./nixos
+          ./nixos/headless
           inputs.home-manager.nixosModules.default
           ({ pkgs, ... }: {
             nixpkgs.overlays = [ rust-overlay.overlays.default ];

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -76,18 +76,6 @@
     SUDO_EDITOR = "nvim";
   };
 
-  # Create a systemd service that runs once whenever
-  # sysinit-reactivation.target is activated to update neovim plugins
-  systemd.services.update-neovim-plugins = {
-    enable = true;
-    description = "Update neovim plugins";
-    after = [ "sysinit-reactivation.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.neovim}/bin/nvim --headless \"+Lazy! sync\" +qa";
-    };
-  };
-
   programs = {
     git = {
       enable = true;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -29,7 +29,7 @@
   boot.loader.systemd-boot.configurationLimit = 15;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  networking.hostName = "ph-nixos"; # Define your hostname.
+  networking.hostName = "server02"; # Define your hostname.
 
   # Enable network manager
   networking.networkmanager.enable = true;
@@ -97,7 +97,7 @@
             pkgs.git.override { withLibsecret = true; }
           }/bin/git-credential-libsecret";
         commit.gpgsign = true;
-        core.editor = "nvim";
+        core.editor = "${pkgs.neovim}/bin/nvim";
       };
     };
     # Enable zsh
@@ -133,25 +133,6 @@
   # };
 
   # List services that you want to enable:
-
-  # Flatpak service to enable users to install flatpak apps
-  services.flatpak = {
-    enable = true;
-  };
-
-  # Enable the OpenSSH daemon.
-  # services.openssh.enable = true;
-  # Optional: use these settings for Public Key authentication only which is
-  # more secure than password authentication.
-  services.openssh = {
-    enable = false;
-    settings = {
-      PasswordAuthentication = true;
-      KbdInteractiveAuthentication = false;
-      # Only enable this if needed
-      # PermitRootLogin = true;
-    };
-  };
 
   # Open ports in the firewall.
   # networking.firewall.allowedTCPPorts = [ ... ];

--- a/nixos/gnome/desktop.nix
+++ b/nixos/gnome/desktop.nix
@@ -56,6 +56,9 @@
   };
 
   # Enable flatpak so we can install third-party apps
+  services.flatpak = {
+    enable = true;
+  };
   xdg.portal = {
     enable = true;
     config.common.default = [ "*" ];

--- a/nixos/hardware-configuration.nix
+++ b/nixos/hardware-configuration.nix
@@ -8,18 +8,18 @@
     [ (modulesPath + "/installer/scan/not-detected.nix")
     ];
 
-  boot.initrd.availableKernelModules = [ "xhci_pci" "thunderbolt" "nvme" "usb_storage" "sd_mod" "rtsx_pci_sdmmc" ];
+  boot.initrd.availableKernelModules = [ "ahci" "ehci_pci" "megaraid_sas" "usb_storage" "usbhid" "sd_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/2c1fbbd4-c9f4-4d82-950a-9586bf5ad650";
+    { device = "/dev/disk/by-uuid/01df5045-d647-4fb2-bd1e-36e27342bc41";
       fsType = "ext4";
     };
 
   fileSystems."/boot" =
-    { device = "/dev/disk/by-uuid/ECDB-7BA7";
+    { device = "/dev/disk/by-uuid/C032-510C";
       fsType = "vfat";
       options = [ "fmask=0077" "dmask=0077" ];
     };
@@ -31,8 +31,10 @@
   # still possible to use this option, but it's recommended to use it in conjunction
   # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp0s13f0u1c2.useDHCP = lib.mkDefault true;
-  # networking.interfaces.wlp89s0.useDHCP = lib.mkDefault true;
+  # networking.interfaces.eno1.useDHCP = lib.mkDefault true;
+  # networking.interfaces.eno2.useDHCP = lib.mkDefault true;
+  # networking.interfaces.eno3.useDHCP = lib.mkDefault true;
+  # networking.interfaces.eno4.useDHCP = lib.mkDefault true;
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;

--- a/nixos/headless/default.nix
+++ b/nixos/headless/default.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+{
+  # Add any imports here for things that need their own config file
+#  imports = [
+#  ];
+
+  # Enable SSH with keys only
+  services.openssh = {
+    enable = true;
+    settings = {
+      PasswordAuthentication = true;
+      KbdInteractiveAuthentication = false;
+      # Only enable if absolutely needed
+      # PermitRootLogin = true;
+    };
+  };
+}

--- a/users/prestonh/config/nvim/lua/plugins/spec3.lua
+++ b/users/prestonh/config/nvim/lua/plugins/spec3.lua
@@ -1,0 +1,22 @@
+return {
+  {
+    "christoomey/vim-tmux-navigator",
+    lazy = false,
+    priority = 2,
+    cmd = {
+      "TmuxNavigateLeft",
+      "TmuxNavigateDown",
+      "TmuxNavigateUp",
+      "TmuxNavigateRight",
+      "TmuxNavigatePrevious",
+    },
+    keys = {
+      { "<c-h>", "<cmd><C-U>TmuxNavigateLeft<cr>" },
+      { "<c-j>", "<cmd><C-U>TmuxNavigateDown<cr>" },
+      { "<c-k>", "<cmd><C-U>TmuxNavigateUp<cr>" },
+      { "<c-l>", "<cmd><C-U>TmuxNavigateRight<cr>" },
+      { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
+    },
+  }
+}
+

--- a/users/prestonh/home-config.nix
+++ b/users/prestonh/home-config.nix
@@ -1,0 +1,53 @@
+{ config, pkgs, ... }:
+
+{
+  # Home Manager is pretty good at managing dotfiles. The primary way to manage
+  # plain files is through 'home.file'.
+  home.file = {
+    # Recursively add all files from the config directory
+    ".config/" = {
+      source = ./config;
+      recursive = true;
+    };
+
+    # zshrc file
+    ".zshrc".source = ./zshrc;
+  };
+
+  # Create a systemd service that runs once whenever
+  # sysinit-reactivation.target is activated to update neovim plugins
+  systemd.user.services.update-neovim-plugins = {
+    Unit = {
+      Description = "Update neovim plugins";
+    };
+    Install = {
+      WantedBy = [ "default.target" "sysinit-reactivation.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.neovim}/bin/nvim --headless '+Lazy! sync' +qa";
+    };
+  };
+
+  # Home Manager can also manage your environment variables through
+  # 'home.sessionVariables'. If you don't want to manage your shell through Home
+  # Manager then you have to manually source 'hm-session-vars.sh' located at
+  # either
+  #
+  #  ~/.nix-profile/etc/profile.d/hm-session-vars.sh
+  #
+  # or
+  #
+  #  ~/.local/state/nix/profiles/profile/etc/profile.d/hm-session-vars.sh
+  #
+  # or
+  #
+  #  /etc/profiles/per-user/prestonh/etc/profile.d/hm-session-vars.sh
+  #
+  home.sessionVariables = {
+    EDITOR = "nvim";
+    VISUAL = "nvim";
+    SUDO_EDITOR = "nvim";
+    TERMINAL = "kitty";
+  };
+}

--- a/users/prestonh/home-config.nix
+++ b/users/prestonh/home-config.nix
@@ -48,6 +48,6 @@
     EDITOR = "nvim";
     VISUAL = "nvim";
     SUDO_EDITOR = "nvim";
-    TERMINAL = "kitty";
+#    TERMINAL = "kitty";
   };
 }

--- a/users/prestonh/home-programs.nix
+++ b/users/prestonh/home-programs.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, ... }:
+
+{
+  # Import larger program configurations
+  imports = [
+    ./programs/tmux.nix
+  ];
+
+  # Add the brave browser
+  # You can also change package to one of the following:
+  #   chromium, google-chrome, google-chrome-beta, google-chrome-dev, brave, or
+  #   vivaldi.
+  programs.chromium = {
+    enable = true;
+    package = pkgs.brave;
+    extensions = [
+      { id = "nngceckbapebfimnlniiiahkandclblb"; }
+    ];
+    commandLineArgs = [
+      # "--argumentHere"
+    ];
+  };
+
+  # Setup local git configuration
+  programs.git = {
+    enable = true;
+    userName = "Preston Hager";
+    userEmail = "preston@hagerfamily.com";
+    signing = {
+      signByDefault = true;
+      key = "preston@hagerfamily.com";
+    };
+    aliases = {
+      ap = "add -p";
+    };
+  };
+}

--- a/users/prestonh/home.nix
+++ b/users/prestonh/home.nix
@@ -1,6 +1,13 @@
-{ config, pkgs, lib ? pkgs.lib, ... }:
+{ config, pkgs, ... }:
 
 {
+  # Import other home manager files
+  imports = [
+    ./home-config.nix
+    ./home-programs.nix
+    ./user-packages.nix
+  ];
+
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
   home.username = "prestonh";
@@ -18,29 +25,20 @@
   # The home.packages option allows you to install Nix packages into your
   # environment.
   home.packages = with pkgs; [
-    # Add packages to just this user
+    # Command line tools
+    # zoxide is the new cd command allowing fuzzy directory changes
     zoxide
+    # fzf (fuzzy finder) allows finding of files via a search box
     fzf
+    # lsd (ls-deluxe) makes listings colorful and easier to read
     lsd
-
-    gcc
-    xclip
-
-    python313Full
-    poetry
-    python311Packages.pyopengl
-
-    nodejs_22
-    nodenv
-
-    thefuck
-
+    # list the directory structure of directory in a branching/tree format
     tree
-
+    # thefuck is a fun command corrector, trying to guess what you meant when
+    # mistyping a command
+    thefuck
+    # markdown viewer (with edit button)
     glow
-
-    gh    # GitHub CLI
-    gnupg
 
     # # It is sometimes useful to fine-tune packages, for example, by applying
     # # overrides. You can do that directly here, just don't forget the
@@ -55,91 +53,6 @@
     #   echo "Hello, ${config.home.username}!"
     # '')
   ];
-
-  # Add unfree packages, only allowing specific packages so that other configs
-  # can't install unwanted unfree packages
-#  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-#     "pkg-name"
-#  ];
-
-  # Add the brave browser
-  # You can also change package to one of the following:
-  #   chromium, google-chrome, google-chrome-beta, google-chrome-dev, brave, or
-  #   vivaldi.
-  programs.chromium = {
-    enable = true;
-    package = pkgs.brave;
-    extensions = [
-      { id = "nngceckbapebfimnlniiiahkandclblb"; }
-    ];
-    commandLineArgs = [
-      # "--argumentHere"
-    ];
-  };
-
-  # Setup local git configuration
-  programs.git = {
-    enable = true;
-    userName = "Preston Hager";
-    userEmail = "preston@hagerfamily.com";
-    signing = {
-      signByDefault = true;
-      key = "preston@hagerfamily.com";
-    };
-    aliases = {
-      ap = "add -p";
-    };
-  };
-
-  # Home Manager is pretty good at managing dotfiles. The primary way to manage
-  # plain files is through 'home.file'.
-  home.file = {
-    # Recursively add all files from the config directory
-    ".config/" = {
-      source = ./config;
-      recursive = true;
-    };
-
-    # zshrc file
-    ".zshrc".source = ./zshrc;
-  };
-
-  # Create a systemd service that runs once whenever
-  # sysinit-reactivation.target is activated to update neovim plugins
-  systemd.user.services.update-neovim-plugins = {
-    Unit = {
-      Description = "Update neovim plugins";
-    };
-    Install = {
-      WantedBy = [ "default.target" "sysinit-reactivation.target" ];
-    };
-    Service = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.neovim}/bin/nvim --headless '+Lazy! sync' +qa";
-    };
-  };
-
-  # Home Manager can also manage your environment variables through
-  # 'home.sessionVariables'. If you don't want to manage your shell through Home
-  # Manager then you have to manually source 'hm-session-vars.sh' located at
-  # either
-  #
-  #  ~/.nix-profile/etc/profile.d/hm-session-vars.sh
-  #
-  # or
-  #
-  #  ~/.local/state/nix/profiles/profile/etc/profile.d/hm-session-vars.sh
-  #
-  # or
-  #
-  #  /etc/profiles/per-user/prestonh/etc/profile.d/hm-session-vars.sh
-  #
-  home.sessionVariables = {
-    EDITOR = "nvim";
-    VISUAL = "nvim";
-    SUDO_EDITOR = "nvim";
-#    TERMINAL = "kitty";
-  };
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;

--- a/users/prestonh/home.nix
+++ b/users/prestonh/home.nix
@@ -79,8 +79,13 @@
 
   # Setup local git configuration
   programs.git = {
+    enable = true;
     userName = "Preston Hager";
     userEmail = "preston@hagerfamily.com";
+    signing = {
+      signByDefault = true;
+      key = "preston@hagerfamily.com";
+    };
     aliases = {
       ap = "add -p";
     };
@@ -97,6 +102,21 @@
 
     # zshrc file
     ".zshrc".source = ./zshrc;
+  };
+
+  # Create a systemd service that runs once whenever
+  # sysinit-reactivation.target is activated to update neovim plugins
+  systemd.user.services.update-neovim-plugins = {
+    Unit = {
+      Description = "Update neovim plugins";
+    };
+    Install = {
+      WantedBy = [ "default.target" "sysinit-reactivation.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.neovim}/bin/nvim --headless '+Lazy! sync' +qa";
+    };
   };
 
   # Home Manager can also manage your environment variables through

--- a/users/prestonh/programs/tmux.nix
+++ b/users/prestonh/programs/tmux.nix
@@ -1,0 +1,99 @@
+{config, pkgs, lib ? pkgs.lib, ... }:
+
+let
+  tmux-super-fingers = pkgs.tmuxPlugins.mkTmuxPlugin
+    {
+      pluginName = "tmux-super-fingers";
+      version = "unstable-2023-01-06";
+      src = pkgs.fetchFromGitHub {
+        owner = "artemave";
+        repo = "tmux_super_fingers";
+        rev = "2771f791a03880b3653c043cff48ee81db66212b";
+        sha256 = "sha256-GnVlV8JRKVx6muVKYvqkCSMds7IBTYp1NFEgQnnuYEc=";
+      };
+    };
+in
+{
+  programs.tmux = {
+    enable = true;
+    shell = "${pkgs.zsh}/bin/zsh";
+    terminal = "tmux-256color";
+    historyLimit = 100000;
+    plugins = with pkgs; [
+      {
+        plugin = tmuxPlugins.catppuccin;
+        extraConfig = '' 
+          set -g @catppuccin_flavour 'mocha'
+          set -g @catppuccin_window_tabs_enabled on
+
+          set -g @catppuccin_window_right_separator "█ "
+          set -g @catppuccin_window_number_position "right"
+          set -g @catppuccin_window_middle_separator " | "
+
+          set -g @catppuccin_window_default_fill "none"
+
+          set -g @catppuccin_window_current_fill "all"
+
+          set -g @catppuccin_status_modules_right "application session user host date_time"
+          set -g @catppuccin_status_left_separator "█"
+          set -g @catppuccin_status_right_separator "█"
+
+          set -g @catppuccin_date_time_text "%Y-%m-%d %H:%M:%S"
+        '';
+      }
+      {
+        plugin = tmux-super-fingers;
+        extraConfig = ''
+          set -g @super-fingers-key f
+        '';
+      }
+
+      tmuxPlugins.better-mouse-mode
+
+      {
+        plugin = tmuxPlugins.vim-tmux-navigator;
+        extraConfig = ''
+          set -g @vim_navigator_mapping_left "C-Left C-h"  # use C-h and C-Left
+          set -g @vim_navigator_mapping_right "C-Right C-l"
+          set -g @vim_navigator_mapping_up "C-k"
+          set -g @vim_navigator_mapping_down "C-j"
+          set -g @vim_navigator_mapping_prev ""  # removes the C-\ binding
+        '';
+      }
+      {
+        plugin = tmuxPlugins.resurrect;
+        extraConfig = ''
+          set -g @resurrect-strategy-vim 'session'
+          set -g @resurrect-strategy-nvim 'session'
+          set -g @resurrect-capture-pane-contents 'on'
+        '';
+      }
+      {
+        plugin = tmuxPlugins.continuum;
+        extraConfig = ''
+          set -g @continuum-restore 'on'
+          set -g @continuum-boot 'on'
+          set -g @continuum-save-interval '10'
+        '';
+      }
+    ];
+    extraConfig = ''
+      unbind C-b
+      set -g prefix C-Space
+      bind C-Space send-prefix
+
+      # Set start of numbering at 1 to make for easier keyboard entry
+      set -g base-index 1
+      setw -g pane-base-index 1
+      # Also reorder windows after removing one in between two
+      set -g renumber-windows on
+
+      set-option -sa terminal-overrides ",xterm*:Tc"
+      set -g mouse on
+
+      # Quick reload for faster development, turn off when not in use
+      bind r source-file $HOME/.config/tmux/tmux.conf \; display "Reloaded!"
+    '';
+  };
+}
+

--- a/users/prestonh/user-packages.nix
+++ b/users/prestonh/user-packages.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, lib ? pkgs.lib, ... }:
+
+{
+  # Import larger declarations of packages here
+  imports = [ ];
+
+  home.packages = with pkgs; [
+    # basic C toolchain
+    gcc
+    xclip
+
+    # Python support, latest is 3.13 as of 28 Sep. 2024
+    python313Full
+    poetry
+    python311Packages.pyopengl
+
+    # NodeJS environments
+    nodejs_22
+    nodenv
+
+    # GitHub CLI
+    gh
+    gnupg
+
+  ];
+
+  # Add unfree packages, only allowing specific packages so that other configs
+  # can't install unwanted unfree packages
+#  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+#     "pkg-name"
+#  ];
+
+}

--- a/users/prestonh/zshrc
+++ b/users/prestonh/zshrc
@@ -32,7 +32,9 @@ alias ltl="lt --color=always | less -R"
 
 # Allow git access as root using user configs
 alias gsudo='sudo git -c "include.path='"${XDG_CONFIG_DIR:-$HOME/.config}/git/config\" -c \"include.path=$HOME/.gitconfig\""
-
+# Do the same for neovim
+alias nvims="sudo XDG_CONFIG_HOME=\"$HOME/.config/\" nvim"
+#-u ${XDG_CONFIG_DIR:-$HOME/.config}/nvim/init.lua"
 
 # Map all the vi's to neovim
 alias vim="nvim"

--- a/users/prestonh/zshrc
+++ b/users/prestonh/zshrc
@@ -30,6 +30,10 @@ alias lt="ls -latr"
 alias lll="l --color=always | less -R"
 alias ltl="lt --color=always | less -R"
 
+# Allow git access as root using user configs
+alias gsudo='sudo git -c "include.path='"${XDG_CONFIG_DIR:-$HOME/.config}/git/config\" -c \"include.path=$HOME/.gitconfig\""
+
+
 # Map all the vi's to neovim
 alias vim="nvim"
 alias vi="nvim"


### PR DESCRIPTION
Headless system configuration now works as expected.

Added a few aliases to the zshrc file: `gsudo` and `nvims`, sudo versions of `git` and `nvim` with the user config.

Added `tmux` including multiple plugins to home manager configuration.