### PR TITLE
Add shellinabox service with HTTPS proxy

### DIFF
--- a/nixos/headless/default.nix
+++ b/nixos/headless/default.nix
@@ -15,6 +15,8 @@
     ../shellinabox.nix
   ];
 
+  services.shellinaboxd.enable = true;
+
   # Enable SSH with keys only
   services.openssh = {
     enable = true;

--- a/nixos/headless/default.nix
+++ b/nixos/headless/default.nix
@@ -25,4 +25,9 @@
       # PermitRootLogin = true;
     };
   };
+
+  # Enable shellinabox service
+  services.shellinaboxd = {
+    enable = true;
+  };
 }

--- a/nixos/headless/default.nix
+++ b/nixos/headless/default.nix
@@ -27,9 +27,4 @@
       # PermitRootLogin = true;
     };
   };
-
-  # Enable shellinabox service
-  services.shellinaboxd = {
-    enable = true;
-  };
 }

--- a/nixos/headless/default.nix
+++ b/nixos/headless/default.nix
@@ -11,6 +11,8 @@
     ../virt-manager.nix
     # Wireguard server
     ../wireguard.nix
+    # Local shellinabox service
+    ../shellinabox.nix
   ];
 
   # Enable SSH with keys only

--- a/nixos/nginx/reverse-proxy.nix
+++ b/nixos/nginx/reverse-proxy.nix
@@ -132,6 +132,13 @@
         };
       });
 
+      "shell.prestonhager.com" = (SSL // {
+        locations."/" = {
+          proxyPass = "http://localhost:4200/";
+          proxyWebsockets = true;
+        };
+      });
+
       # Games from pterodactyl panel
       "pong.prestonhager.com" = (SSL // {
         locations."/" = {

--- a/nixos/shellinabox.nix
+++ b/nixos/shellinabox.nix
@@ -1,0 +1,51 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.shellinabox;
+  package = cfg.package or (pkgs.callPackage ../pkgs/shellinabox {});
+  port = toString cfg.port;
+  user = cfg.user;
+  bindAddress = "127.0.0.1";
+  execStart = "${package}/bin/shellinaboxd --no-beep --disable-ssl --port=${port} --user=${user} --group=${user} --localhost-only";
+in
+{
+  options.services.shellinabox = {
+    enable = lib.mkEnableOption "ShellInABox web terminal";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../pkgs/shellinabox {};
+      description = "The shellinabox package to use.";
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4200;
+      description = "Port shellinabox listens on.";
+    };
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "shellinabox";
+      description = "User to run the service as.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      description = "ShellInABox service user";
+    };
+
+    systemd.services.shellinabox = {
+      description = "ShellInABox Web Terminal";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = execStart;
+        User = cfg.user;
+        Group = cfg.user;
+        Restart = "on-failure";
+      };
+    };
+
+    # do not open port; only reverse proxy via localhost
+  };
+}

--- a/nixos/shellinabox.nix
+++ b/nixos/shellinabox.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 let
-  cfg = config.services.shellinabox;
+  cfg = config.services.shellinaboxd;
   package = cfg.package or (pkgs.callPackage ../pkgs/shellinabox {});
   port = toString cfg.port;
   user = cfg.user;
@@ -9,7 +9,7 @@ let
   execStart = "${package}/bin/shellinaboxd --no-beep --disable-ssl --port=${port} --user=${user} --group=${user} --localhost-only";
 in
 {
-  options.services.shellinabox = {
+  options.services.shellinaboxd = {
     enable = lib.mkEnableOption "ShellInABox web terminal";
     package = lib.mkOption {
       type = lib.types.package;

--- a/nixos/shellinabox.nix
+++ b/nixos/shellinabox.nix
@@ -32,7 +32,10 @@ in
     users.users.${cfg.user} = {
       isSystemUser = true;
       description = "ShellInABox service user";
+      group = cfg.user;
     };
+
+    users.groups.${cfg.user} = { };
 
     systemd.services.shellinabox = {
       description = "ShellInABox Web Terminal";

--- a/pkgs/shellinabox/default.nix
+++ b/pkgs/shellinabox/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, zlib }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "shellinabox";
@@ -12,11 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ zlib ];
+  buildInputs = [ openssl zlib ];
 
   configureFlags = [
     "--disable-init"
-    "--disable-ssl"
     "--disable-runtime-loading"
   ];
 

--- a/pkgs/shellinabox/default.nix
+++ b/pkgs/shellinabox/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "shellinabox";
-  version = "unstable-2024-04-16";
+  version = "v2.20";
 
   src = fetchFromGitHub {
     owner = "shellinabox";
@@ -27,3 +27,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
+
+
+

--- a/pkgs/shellinabox/default.nix
+++ b/pkgs/shellinabox/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "shellinabox";
+  version = "unstable-2024-04-16";
+
+  src = fetchFromGitHub {
+    owner = "shellinabox";
+    repo = "shellinabox";
+    rev = "5c7fb5cde2d2a74775af040549bb5cb11aae6790";
+    sha256 = "sha256-2cnPPXoN2oHhWAElaVfXr1ZAKSFJnCI9FXqyIKBXrsI=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ zlib ];
+
+  configureFlags = [
+    "--disable-init"
+    "--disable-ssl"
+    "--disable-runtime-loading"
+  ];
+
+  meta = with lib; {
+    description = "Web-based AJAX terminal emulator";
+    homepage = "https://github.com/shellinabox/shellinabox";
+    license = licenses.gpl2Plus;
+    maintainers = [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/shellinabox/flake.nix
+++ b/pkgs/shellinabox/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Shellinabox custom package";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.callPackage ./default.nix {};
+      });
+}


### PR DESCRIPTION
## Summary
- add a custom `shellinabox` systemd module
- enable shellinabox service in `headless` NixOS profile
- proxy the service through nginx with SSL

## Testing
- ❌ `nix --extra-experimental-features 'nix-command flakes' build --no-write-lock-file ./pkgs/shellinabox#default` (interrupted due to long build)
- ❌ `nix --extra-experimental-features 'nix-command flakes' flake check` (interrupted due to long evaluation)

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68410bff2f50832ca336fed6a9289918